### PR TITLE
Refs #35: Add aws-iam-authenticator

### DIFF
--- a/Dockerfile-aws
+++ b/Dockerfile-aws
@@ -3,7 +3,9 @@ FROM alpine:3.9 as builder
 RUN set -x \
 	&& apk add --no-cache \
 		bc \
+		curl \
 		gcc \
+		git \
 		libffi-dev \
 		make \
 		musl-dev \
@@ -43,6 +45,21 @@ RUN set -x \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf \
 	&& aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
 
+RUN set -x \
+	&& git clone https://github.com/kubernetes-sigs/aws-iam-authenticator /tmp/aws-iam-authenticator \
+	&& cd /tmp/aws-iam-authenticator \
+	&& IAM_AUTH_VERSION="$( git tag --sort=-creatordate \
+		| grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| head -1 \
+		| sed 's/^v//g' \
+	)" \
+	&& curl -sS -L -b cookies.txt -c cookies.txt \
+		-o /usr/bin/aws-iam-authenticator \
+		-H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.89 Safari/537.36" \
+		"https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${IAM_AUTH_VERSION}/aws-iam-authenticator_${IAM_AUTH_VERSION}_linux_amd64" \
+	&& chmod +x /usr/bin/aws-iam-authenticator \
+	&& aws-iam-authenticator version | grep "\"${IAM_AUTH_VERSION}\""
+
 
 FROM alpine:3.9 as production
 LABEL \
@@ -53,6 +70,7 @@ COPY --from=builder /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-pa
 COPY --from=builder /usr/bin/ansible /usr/bin/ansible
 COPY --from=builder /usr/bin/ansible-connection /usr/bin/ansible-connection
 COPY --from=builder /usr/bin/aws /usr/bin/aws
+COPY --from=builder /usr/bin/aws-iam-authenticator /usr/bin/aws-iam-authenticator
 
 ENV \
 	MY_USER=ansible \

--- a/Dockerfile-awshelm
+++ b/Dockerfile-awshelm
@@ -3,6 +3,7 @@ FROM alpine:3.9 as builder
 RUN set -x \
 	&& apk add --no-cache \
 		bc \
+		curl \
 		gcc \
 		git \
 		libffi-dev \
@@ -45,12 +46,26 @@ RUN set -x \
 	&& aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
 
 RUN set -x \
+	&& git clone https://github.com/kubernetes-sigs/aws-iam-authenticator /tmp/aws-iam-authenticator \
+	&& cd /tmp/aws-iam-authenticator \
+	&& IAM_AUTH_VERSION="$( git tag --sort=-creatordate \
+		| grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| head -1 \
+		| sed 's/^v//g' \
+	)" \
+	&& curl -sS -L -b cookies.txt -c cookies.txt \
+		-o /usr/bin/aws-iam-authenticator \
+		-H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.89 Safari/537.36" \
+		"https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${IAM_AUTH_VERSION}/aws-iam-authenticator_${IAM_AUTH_VERSION}_linux_amd64" \
+	&& chmod +x /usr/bin/aws-iam-authenticator \
+	&& aws-iam-authenticator version | grep "\"${IAM_AUTH_VERSION}\""
+
+RUN set -x \
 	&& pip3 install --no-cache-dir --no-compile openshift \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 RUN set -x \
-	&& apk add --no-cache curl \
 	&& curl -sS -L -o /usr/bin/kubectl \
 		https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
 	&& chmod +x /usr/bin/kubectl \
@@ -70,6 +85,7 @@ RUN set -x \
 	&& chmod +x /usr/bin/helm \
 	&& /usr/bin/helm version | grep -E "${HELM}" | grep -E "${version}"
 
+
 FROM alpine:3.9 as production
 LABEL \
 	maintainer="cytopia <cytopia@everythingcli.org>" \
@@ -79,6 +95,7 @@ COPY --from=builder /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-pa
 COPY --from=builder /usr/bin/ansible /usr/bin/ansible
 COPY --from=builder /usr/bin/ansible-connection /usr/bin/ansible-connection
 COPY --from=builder /usr/bin/aws /usr/bin/aws
+COPY --from=builder /usr/bin/aws-iam-authenticator /usr/bin/aws-iam-authenticator
 COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
 COPY --from=builder /usr/bin/helm /usr/bin/helm
 

--- a/Dockerfile-awsk8s
+++ b/Dockerfile-awsk8s
@@ -3,7 +3,9 @@ FROM alpine:3.9 as builder
 RUN set -x \
 	&& apk add --no-cache \
 		bc \
+		curl \
 		gcc \
+		git \
 		libffi-dev \
 		make \
 		musl-dev \
@@ -44,12 +46,26 @@ RUN set -x \
 	&& aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
 
 RUN set -x \
+	&& git clone https://github.com/kubernetes-sigs/aws-iam-authenticator /tmp/aws-iam-authenticator \
+	&& cd /tmp/aws-iam-authenticator \
+	&& IAM_AUTH_VERSION="$( git tag --sort=-creatordate \
+		| grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| head -1 \
+		| sed 's/^v//g' \
+	)" \
+	&& curl -sS -L -b cookies.txt -c cookies.txt \
+		-o /usr/bin/aws-iam-authenticator \
+		-H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.89 Safari/537.36" \
+		"https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${IAM_AUTH_VERSION}/aws-iam-authenticator_${IAM_AUTH_VERSION}_linux_amd64" \
+	&& chmod +x /usr/bin/aws-iam-authenticator \
+	&& aws-iam-authenticator version | grep "\"${IAM_AUTH_VERSION}\""
+
+RUN set -x \
 	&& pip3 install --no-cache-dir --no-compile openshift \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 RUN set -x \
-	&& apk add --no-cache curl \
 	&& curl -sS -L -o /usr/bin/kubectl \
 		https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
 	&& chmod +x /usr/bin/kubectl \
@@ -65,6 +81,7 @@ COPY --from=builder /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-pa
 COPY --from=builder /usr/bin/ansible /usr/bin/ansible
 COPY --from=builder /usr/bin/ansible-connection /usr/bin/ansible-connection
 COPY --from=builder /usr/bin/aws /usr/bin/aws
+COPY --from=builder /usr/bin/aws-iam-authenticator /usr/bin/aws-iam-authenticator
 COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
 
 ENV \

--- a/Dockerfile-awskops
+++ b/Dockerfile-awskops
@@ -3,6 +3,7 @@ FROM alpine:3.9 as builder
 RUN set -x \
 	&& apk add --no-cache \
 		bc \
+		curl \
 		gcc \
 		git \
 		libffi-dev \
@@ -45,12 +46,26 @@ RUN set -x \
 	&& aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
 
 RUN set -x \
+	&& git clone https://github.com/kubernetes-sigs/aws-iam-authenticator /tmp/aws-iam-authenticator \
+	&& cd /tmp/aws-iam-authenticator \
+	&& IAM_AUTH_VERSION="$( git tag --sort=-creatordate \
+		| grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| head -1 \
+		| sed 's/^v//g' \
+	)" \
+	&& curl -sS -L -b cookies.txt -c cookies.txt \
+		-o /usr/bin/aws-iam-authenticator \
+		-H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.89 Safari/537.36" \
+		"https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${IAM_AUTH_VERSION}/aws-iam-authenticator_${IAM_AUTH_VERSION}_linux_amd64" \
+	&& chmod +x /usr/bin/aws-iam-authenticator \
+	&& aws-iam-authenticator version | grep "\"${IAM_AUTH_VERSION}\""
+
+RUN set -x \
 	&& pip3 install --no-cache-dir --no-compile openshift \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 RUN set -x \
-	&& apk add --no-cache curl \
 	&& curl -sS -L -o /usr/bin/kubectl \
 		https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
 	&& chmod +x /usr/bin/kubectl \
@@ -78,6 +93,7 @@ COPY --from=builder /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-pa
 COPY --from=builder /usr/bin/ansible /usr/bin/ansible
 COPY --from=builder /usr/bin/ansible-connection /usr/bin/ansible-connection
 COPY --from=builder /usr/bin/aws /usr/bin/aws
+COPY --from=builder /usr/bin/aws-iam-authenticator /usr/bin/aws-iam-authenticator
 COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
 COPY --from=builder /usr/bin/kops /usr/bin/kops
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following table shows a quick overview. For more details see further down be
 | tools   | base          | `dnspython`, `mitogen` | `bash`, `git`, `gpg`, `jq`, `ssh` |
 | infra   | tools         | `docker`, `pexpect`, `psycopg2`, `pypsexec`, `pymongo`, `PyMySQL`, `smbprotocol` | - |
 | azure   | tools         | `azure`                | - |
-| aws     | tools         | `awscli`, `botocore`, `boto`, `boto3` | `aws` |
+| aws     | tools         | `awscli`, `botocore`, `boto`, `boto3` | `aws`, `aws-iam-authenticator` |
 | awsk8s  | aws           | `openshift`            | `kubectl` |
 | awskops | awsk8s        | -                      | `kops` |
 | awshelm | awsk8s        | -                      | `helm` |


### PR DESCRIPTION
# aws-iam-authenticator

This PR adds `aws-iam-authenticator` to the following Ansible flavours:

* `aws`
* `awsk8s`
* `awskops`
* `awshelm`

### Related issues

* Fixes #35 