### PR TITLE
fix: add libpq so that we can load psycopg2 in python

### DIFF
--- a/Dockerfile-infra
+++ b/Dockerfile-infra
@@ -17,9 +17,9 @@ RUN set -eux \
 		pip3 install --no-cache-dir --no-compile ansible; \
 	else \
 		pip3 install --no-cache-dir --no-compile "ansible>=${VERSION},<$(echo "${VERSION}+0.1" | bc)"; \
-	fi #\
-    # && find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
-    #&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
+	fi \
+    && find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
+    && find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 RUN set -eux \
 	&& pip3 install --no-cache-dir --no-compile dnspython \

--- a/Dockerfile-infra
+++ b/Dockerfile-infra
@@ -17,9 +17,9 @@ RUN set -eux \
 		pip3 install --no-cache-dir --no-compile ansible; \
 	else \
 		pip3 install --no-cache-dir --no-compile "ansible>=${VERSION},<$(echo "${VERSION}+0.1" | bc)"; \
-	fi \
-	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
-	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
+	fi #\
+    # && find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
+    #&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 RUN set -eux \
 	&& pip3 install --no-cache-dir --no-compile dnspython \

--- a/Dockerfile-infra
+++ b/Dockerfile-infra
@@ -91,6 +91,7 @@ RUN set -eux \
 		git \
 		gnupg \
 		jq \
+		libpq \
 		openssh-client \
 		python3 \
 	\


### PR DESCRIPTION
Hi,

Thanks for the useful docker images! I found that the 2.9-infra image does not work properly with an ansible playbook that uses the `postgresql` module:

```
failed: [localhost] (item={'name': 'testme1', 'state': 'absent'}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "testme1", "state": "absent"}, "msg": "Failed to import the required Python library (psycopg2) on 57b8a86e-55fd-4c7b-520b-260ce369eb52's Python /usr/bin/python. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```
```
docker run --rm -it cytopia/ansible:2.9-infra /bin/sh
[INFO] root> /bin/sh
/data # python
Python 3.6.9 (default, Oct 17 2019, 11:10:22) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import psycopg2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/psycopg2/__init__.py", line 50, in <module>
    from psycopg2._psycopg import (                     # noqa
ImportError: Error loading shared library libpq.so.5: No such file or directory (needed by /usr/lib/python3.6/site-packages/psycopg2/_psycopg.cpython-36m-x86_64-linux-gnu.so)
>>> 
```

This PR adds `libpq`, so that `psycopg2` can be properly imported in Python.