### PR TITLE
Add jsondiff python library on Docker-file-tools

### DIFF
--- a/Dockerfile-tools
+++ b/Dockerfile-tools
@@ -33,6 +33,11 @@ RUN set -eux \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 RUN set -eux \
+	&& pip3 install --no-cache-dir --no-compile jsondiff \
+	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
+	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
+
+RUN set -eux \
 	&& YQ="$( curl -L -sS -o /dev/null -w %{url_effective} https://github.com/mikefarah/yq/releases/latest | sed 's/^.*\///g' )" \
 	&& curl -L -sS https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64 > /usr/bin/yq \
 	&& chmod +x /usr/bin/yq

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following table shows a quick overview. For more details see further down be
 | Flavour | Inherits from | Additional Python libs | Additional binaries |
 |---------|---------------|------------------------|---------------------|
 | base    | -             | `cffi`, `cryptography`, `Jinja2`, `PyYAML` | - |
-| tools   | base          | `dnspython`, `mitogen` | `bash`, `git`, `gpg`, `jq`, `ssh`, `yq` |
+| tools   | base          | `dnspython`, `mitogen`, `jsondiff`  | `bash`, `git`, `gpg`, `jq`, `ssh`, `yq` |
 | infra   | tools         | `docker`, `docker-compose`, `paramiko`, `pexpect`, `psycopg2`, `pypsexec`, `pymongo`, `PyMySQL`, `smbprotocol` | `rsync` |
 | azure   | tools         | `azure-*`              | - |
 | aws     | tools         | `awscli`, `botocore`, `boto`, `boto3` | `aws`, `aws-iam-authenticator` |


### PR DESCRIPTION
The jsondiff python library is required to work with the docker stack module https://docs.ansible.com/ansible/latest/modules/docker_stack_module.html