### PR TITLE
Add k8s (python kubernetes) support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
             DOCKER_TAG_AZURE="${VERSION}-azure"
             DOCKER_TAG_AWS="${VERSION}-aws"
             DOCKER_TAG_AWSK8S="${VERSION}-awsk8s"
+            DOCKER_TAG_K8S="${VERSION}-k8s"
           else
             DOCKER_TAG_BASE="${VERSION}-${GIT_SLUG}"
             DOCKER_TAG_TOOLS="${VERSION}-tools-${GIT_SLUG}"
@@ -85,6 +86,7 @@ jobs:
             DOCKER_TAG_AZURE="${VERSION}-azure-${GIT_SLUG}"
             DOCKER_TAG_AWS="${VERSION}-aws-${GIT_SLUG}"
             DOCKER_TAG_AWSK8S="${VERSION}-awsk8s-${GIT_SLUG}"
+            DOCKER_TAG_K8S="${VERSION}-k8s-${GIT_SLUG}"
           fi
 
           # Output
@@ -96,6 +98,7 @@ jobs:
           echo "DOCKER_TAG_AZURE=${DOCKER_TAG_AZURE}"
           echo "DOCKER_TAG_AWS=${DOCKER_TAG_AWS}"
           echo "DOCKER_TAG_AWSK8S=${DOCKER_TAG_AWSK8S}"
+          echo "DOCKER_TAG_K8S=${DOCKER_TAG_K8S}"
 
           # Export variable
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
@@ -107,6 +110,7 @@ jobs:
           echo "DOCKER_TAG_AZURE=${DOCKER_TAG_AZURE}"   >> ${GITHUB_ENV}
           echo "DOCKER_TAG_AWS=${DOCKER_TAG_AWS}"       >> ${GITHUB_ENV}
           echo "DOCKER_TAG_AWSK8S=${DOCKER_TAG_AWSK8S}" >> ${GITHUB_ENV}
+          echo "DOCKER_TAG_K8S=${DOCKER_TAG_K8S}"       >> ${GITHUB_ENV}
         env:
           VERSION: ${{ matrix.version }}
 
@@ -222,6 +226,22 @@ jobs:
 
 
       # ------------------------------------------------------------
+      # K8s
+      # ------------------------------------------------------------
+      - name: Build Ansible K8s
+        run: |
+          scripts/retry make build ANSIBLE=${VERSION} FLAVOUR=k8s
+        env:
+          VERSION: ${{ matrix.version }}
+
+      - name: Test Ansible K8s
+        run: |
+          scripts/retry make test ANSIBLE=${VERSION} FLAVOUR=k8s
+        env:
+          VERSION: ${{ matrix.version }}
+
+
+      # ------------------------------------------------------------
       # Deploy
       # ------------------------------------------------------------
       - name: Publish images (only repo owner)
@@ -236,6 +256,7 @@ jobs:
           echo "DOCKER_TAG_AZURE=${DOCKER_TAG_AZURE}"
           echo "DOCKER_TAG_AWS=${DOCKER_TAG_AWS}"
           echo "DOCKER_TAG_AWSK8S=${DOCKER_TAG_AWSK8S}"
+          echo "DOCKER_TAG_K8S=${DOCKER_TAG_K8S}"
 
           # Tag image
           scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=base   TAG=${DOCKER_TAG_BASE}
@@ -244,6 +265,7 @@ jobs:
           scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=azure  TAG=${DOCKER_TAG_AZURE}
           scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=aws    TAG=${DOCKER_TAG_AWS}
           scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=awsk8s TAG=${DOCKER_TAG_AWSK8S}
+          scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=k8s TAG=${DOCKER_TAG_K8S}
           docker images | grep cytopia/ansible
 
           # Login
@@ -256,6 +278,7 @@ jobs:
           scripts/retry make push TAG=${DOCKER_TAG_AZURE}
           scripts/retry make push TAG=${DOCKER_TAG_AWS}
           scripts/retry make push TAG=${DOCKER_TAG_AWSK8S}
+          scripts/retry make push TAG=${DOCKER_TAG_K8S}
         env:
           VERSION: ${{ matrix.version }}
         # https://help.github.com/en/github/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#functions

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,6 +77,7 @@ jobs:
             DOCKER_TAG_AZURE="${VERSION}-azure"
             DOCKER_TAG_AWS="${VERSION}-aws"
             DOCKER_TAG_AWSK8S="${VERSION}-awsk8s"
+            DOCKER_TAG_K8S="${VERSION}-k8s"
           else
             DOCKER_TAG_BASE="${VERSION}-${GIT_SLUG}"
             DOCKER_TAG_TOOLS="${VERSION}-tools-${GIT_SLUG}"
@@ -84,6 +85,7 @@ jobs:
             DOCKER_TAG_AZURE="${VERSION}-azure-${GIT_SLUG}"
             DOCKER_TAG_AWS="${VERSION}-aws-${GIT_SLUG}"
             DOCKER_TAG_AWSK8S="${VERSION}-awsk8s-${GIT_SLUG}"
+            DOCKER_TAG_K8S="${VERSION}-k8s-${GIT_SLUG}"
           fi
 
           # Output
@@ -95,6 +97,7 @@ jobs:
           echo "DOCKER_TAG_AZURE=${DOCKER_TAG_AZURE}"
           echo "DOCKER_TAG_AWS=${DOCKER_TAG_AWS}"
           echo "DOCKER_TAG_AWSK8S=${DOCKER_TAG_AWSK8S}"
+          echo "DOCKER_TAG_K8S=${DOCKER_TAG_K8S}"
 
           # Export variable
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
@@ -106,6 +109,7 @@ jobs:
           echo "DOCKER_TAG_AZURE=${DOCKER_TAG_AZURE}"   >> ${GITHUB_ENV}
           echo "DOCKER_TAG_AWS=${DOCKER_TAG_AWS}"       >> ${GITHUB_ENV}
           echo "DOCKER_TAG_AWSK8S=${DOCKER_TAG_AWSK8S}" >> ${GITHUB_ENV}
+          echo "DOCKER_TAG_K8S=${DOCKER_TAG_K8S}"       >> ${GITHUB_ENV}
         env:
           VERSION: ${{ matrix.version }}
 
@@ -221,6 +225,22 @@ jobs:
 
 
       # ------------------------------------------------------------
+      # K8s
+      # ------------------------------------------------------------
+      - name: Build Ansible K8s
+        run: |
+          scripts/retry make build ANSIBLE=${VERSION} FLAVOUR=k8s
+        env:
+          VERSION: ${{ matrix.version }}
+
+      - name: Test Ansible K8s
+        run: |
+          scripts/retry make test ANSIBLE=${VERSION} FLAVOUR=k8s
+        env:
+          VERSION: ${{ matrix.version }}
+
+
+      # ------------------------------------------------------------
       # Deploy
       # ------------------------------------------------------------
       - name: Publish images (only repo owner)
@@ -235,6 +255,7 @@ jobs:
           echo "DOCKER_TAG_AZURE=${DOCKER_TAG_AZURE}"
           echo "DOCKER_TAG_AWS=${DOCKER_TAG_AWS}"
           echo "DOCKER_TAG_AWSK8S=${DOCKER_TAG_AWSK8S}"
+          echo "DOCKER_TAG_K8S=${DOCKER_TAG_K8S}"
 
           # Tag image
           scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=base   TAG=${DOCKER_TAG_BASE}
@@ -243,6 +264,7 @@ jobs:
           scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=azure  TAG=${DOCKER_TAG_AZURE}
           scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=aws    TAG=${DOCKER_TAG_AWS}
           scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=awsk8s TAG=${DOCKER_TAG_AWSK8S}
+          scripts/retry make tag ANSIBLE=${VERSION} FLAVOUR=k8s TAG=${DOCKER_TAG_K8S}
           docker images | grep cytopia/ansible
 
           # Login
@@ -255,6 +277,7 @@ jobs:
           scripts/retry make push TAG=${DOCKER_TAG_AZURE}
           scripts/retry make push TAG=${DOCKER_TAG_AWS}
           scripts/retry make push TAG=${DOCKER_TAG_AWSK8S}
+          scripts/retry make push TAG=${DOCKER_TAG_K8S}
         env:
           VERSION: ${{ matrix.version }}
         # https://help.github.com/en/github/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#functions

--- a/Dockerfiles/Dockerfile-k8s
+++ b/Dockerfiles/Dockerfile-k8s
@@ -1,0 +1,43 @@
+ARG VERSION
+
+# --------------------------------------------------------------------------------------------------
+# Builder Image
+# --------------------------------------------------------------------------------------------------
+# See ./builder for this image
+FROM cytopia/ansible-builder as builder
+
+# Python packages (copied to final image)
+RUN set -eux \
+	&& pip3 install --no-cache-dir --no-compile \
+		--ignore-installed PyYAML \
+		docker \
+		kubernetes \
+	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
+	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
+
+
+# --------------------------------------------------------------------------------------------------
+# Final Image
+# --------------------------------------------------------------------------------------------------
+FROM cytopia/ansible:${VERSION}-tools as production
+ARG VERSION
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+#LABEL "org.opencontainers.image.created"=""
+#LABEL "org.opencontainers.image.version"=""
+#LABEL "org.opencontainers.image.revision"=""
+LABEL "maintainer"="cytopia <cytopia@everythingcli.org>"
+LABEL "org.opencontainers.image.authors"="cytopia <cytopia@everythingcli.org>"
+LABEL "org.opencontainers.image.vendor"="cytopia"
+LABEL "org.opencontainers.image.licenses"="MIT"
+LABEL "org.opencontainers.image.url"="https://github.com/cytopia/docker-ansible"
+LABEL "org.opencontainers.image.documentation"="https://github.com/cytopia/docker-ansible"
+LABEL "org.opencontainers.image.source"="https://github.com/cytopia/docker-ansible"
+LABEL "org.opencontainers.image.ref.name"="Ansible ${VERSION} k8s"
+LABEL "org.opencontainers.image.title"="Ansible ${VERSION} k8s"
+LABEL "org.opencontainers.image.description"="Ansible ${VERSION} k8s"
+
+COPY --from=builder /usr/lib/python3.8/site-packages/ /usr/lib/python3.8/site-packages/
+
+WORKDIR /data
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ help:
 	@echo "    make build ANSIBLE=2.3 FLAVOUR=awsk8s"
 	@echo "    make build ANSIBLE=2.3 FLAVOUR=awshelm HELM=2.11"
 	@echo "    make build ANSIBLE=2.3 FLAVOUR=awskops KOPS=1.15"
+	@echo "    make build ANSIBLE=2.3 FLAVOUR=k8s"
 	@echo
 	@echo "--------------------------------------------------------------------------------"
 	@echo " Test Targets"
@@ -67,6 +68,7 @@ help:
 	@echo "    make test ANSIBLE=2.3 FLAVOUR=awsk8s"
 	@echo "    make test ANSIBLE=2.3 FLAVOUR=awshelm HELM=2.11"
 	@echo "    make test ANSIBLE=2.3 FLAVOUR=awskops KOPS=1.15"
+	@echo "    make test ANSIBLE=2.3 FLAVOUR=k8s"
 	@echo
 	@echo "--------------------------------------------------------------------------------"
 	@echo " Tagging Target"
@@ -82,6 +84,7 @@ help:
 	@echo "    make tag ANSIBLE=2.3 FLAVOUR=awsk8s TAG=2.3-awsk8s-mysuffix"
 	@echo "    make tag ANSIBLE=2.3 FLAVOUR=awshelm HELM=2.11 TAG=2.3-awshelm-mysuffix"
 	@echo "    make tag ANSIBLE=2.3 FLAVOUR=awskops KOPS=1.15 TAG=2.3-awskops-mysuffix"
+	@echo "    make tag ANSIBLE=2.3 FLAVOUR=k8s TAG=2.3-k8s-mysuffix"
 	@echo
 	@echo "--------------------------------------------------------------------------------"
 	@echo " MISC Targets"
@@ -278,6 +281,7 @@ test-python-libs:
 	REQUIRED_AWSK8S="openshift"; \
 	REQUIRED_AWSKOPS=""; \
 	REQUIRED_AWSHELM=""; \
+	REQUIRED_K8S="docker kubernetes"; \
 	\
 	\
 	if [ "$(FLAVOUR)" = "base" ]; then \
@@ -397,9 +401,35 @@ test-python-libs:
 				exit 1; \
 			fi; \
 		done; \
+		for lib in $${REQUIRED_K8S}; do \
+			if ! echo "$${LIBS}" | grep -E "^$${lib}" >/dev/null; then \
+				echo "[OK] unwanted lib not available: $${lib}"; \
+			else \
+				echo "[FAILED] unwanted lib available: $${lib}"; \
+				exit 1; \
+			fi; \
+		done; \
 	\
 	elif [ "$(FLAVOUR)" = "awshelm" ]; then \
 		for lib in $$( echo $${REQUIRED_BASE} $${REQUIRED_TOOLS} $${REQUIRED_AWS} $${REQUIRED_AWSK8S} $${REQUIRED_AWSHELM} ); do \
+			if echo "$${LIBS}" | grep -E "^$${lib}" >/dev/null; then \
+				echo "[OK] required lib available: $${lib}"; \
+			else \
+				echo "[FAILED] required lib not available: $${lib}"; \
+				exit 1; \
+			fi; \
+		done; \
+		for lib in $${REQUIRED_K8S}; do \
+			if ! echo "$${LIBS}" | grep -E "^$${lib}" >/dev/null; then \
+				echo "[OK] unwanted lib not available: $${lib}"; \
+			else \
+				echo "[FAILED] unwanted lib available: $${lib}"; \
+				exit 1; \
+			fi; \
+		done; \
+	\
+	elif [ "$(FLAVOUR)" = "k8s" ]; then \
+		for lib in $$( echo $${REQUIRED_BASE} $${REQUIRED_TOOLS} $${REQUIRED_K8S} ); do \
 			if echo "$${LIBS}" | grep -E "^$${lib}" >/dev/null; then \
 				echo "[OK] required lib available: $${lib}"; \
 			else \
@@ -435,6 +465,7 @@ test-binaries:
 	REQUIRED_AWSK8S="kubectl oc"; \
 	REQUIRED_AWSKOPS="kops"; \
 	REQUIRED_AWSHELM="helm"; \
+	REQUIRED_K8S=""; \
 	\
 	\
 	if [ "$(FLAVOUR)" = "base" ]; then \
@@ -554,9 +585,35 @@ test-binaries:
 				exit 1; \
 			fi; \
 		done; \
+		for bin in $${REQUIRED_K8S}; do \
+			if ! echo "$${BINS}" | grep -E "^$${bin}" >/dev/null; then \
+				echo "[OK] unwanted bin not available: $${bin}"; \
+			else \
+				echo "[FAILED] unwanted bin available: $${bin}"; \
+				exit 1; \
+			fi; \
+		done; \
 	\
 	elif [ "$(FLAVOUR)" = "awshelm" ]; then \
 		for bin in $$( echo $${REQUIRED_BASE} $${REQUIRED_TOOLS} $${REQUIRED_AWS} $${REQUIRED_AWSK8S} $${REQUIRED_AWSHELM} ); do \
+			if echo "$${BINS}" | grep -E "^$${bin}" >/dev/null; then \
+				echo "[OK] required bin available: $${bin}"; \
+			else \
+				echo "[FAILED] required bin not available: $${bin}"; \
+				exit 1; \
+			fi; \
+		done; \
+		for bin in $${REQUIRED_K8S}; do \
+			if ! echo "$${BINS}" | grep -E "^$${bin}" >/dev/null; then \
+				echo "[OK] unwanted bin not available: $${bin}"; \
+			else \
+				echo "[FAILED] unwanted bin available: $${bin}"; \
+				exit 1; \
+			fi; \
+		done; \
+	\
+	elif [ "$(FLAVOUR)" = "k8s" ]; then \
+		for bin in $$( echo $${REQUIRED_BASE} $${REQUIRED_TOOLS} $${REQUIRED_K8S} ); do \
 			if echo "$${BINS}" | grep -E "^$${bin}" >/dev/null; then \
 				echo "[OK] required bin available: $${bin}"; \
 			else \

--- a/README.md
+++ b/README.md
@@ -71,20 +71,20 @@ This repository provides many different Ansible flavours (each flavour also divi
 
 The following tree shows how the different flavours derive from each other (each child has all the tools and features of its parent plus its own additions).
 ```css
-       base                    #docker-tag:  :latest
-         |                                   :<version>
-         |
-       tools                   #docker-tag:  :latest-tools
-      /  |  \                                :<version>-tools
-     /   |   \
-infra  azure  aws              #docker-tag:  :latest-infra     :latest-azure     :latest-aws
-               |                             :<version>-infra  :<version>-azure  :<version>-aws
+          base                    #docker-tag:  :latest
+            |                                   :<version>
+            |
+          tools                   #docker-tag:  :latest-tools
+       /  /  \  \                               :<version>-tools
+      /  /    \  \
+infra  azure  aws  k8s            #docker-tag:  :latest-infra     :latest-azure     :latest-aws     :latest-k8s
+               |                                :<version>-infra  :<version>-azure  :<version>-aws  :<version>-k8s
                |
-             awsk8s            #docker-tag:  :latest-awsk8s
-              /  \                           :<version>-awsk8s
+             awsk8s               #docker-tag:  :latest-awsk8s
+              /  \                              :<version>-awsk8s
              /    \
-        awskops  awshelm       #docker-tag   :latest-awskops     :latest-awshelm
-                                             :<version>-awskops  :<version>-awshelm
+        awskops  awshelm          #docker-tag   :latest-awskops     :latest-awshelm
+                                                :<version>-awskops  :<version>-awshelm
 ```
 > <sub>`<version>` refers to the latest<sup>\[1\],</sup> patch-level version of Ansible. E.g.: `2.9`, `2.10`, `2.11`, ...</sub><br/>
 > <sub>\[1\]: latest as docker images are (re)built every night via CI against the latest available patch level version of Ansible</sub>
@@ -102,6 +102,7 @@ The following table shows a quick overview of provided libraries and tools for e
 | awsk8s  | aws      | `openshift`            | `kubectl`, `oc` |
 | awskops | awsk8s   | -                      | `kops` |
 | awshelm | awsk8s   | -                      | `helm` |
+| k8s     | tools    | `docker`, `kubernetes` | - |
 
 
 ### Ansible base
@@ -719,6 +720,25 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.4-awshelm2.11`    | Latest stable Ansible 2.4.x version  |
 | `2.3-awshelm2.11`    | Latest stable Ansible 2.3.x version  |
 
+### Ansible k8s
+[![](https://images.microbadger.com/badges/version/cytopia/ansible:latest-k8s.svg?&kill_cache=1)](https://microbadger.com/images/cytopia/ansible:latest-k8s "ansible")
+[![](https://images.microbadger.com/badges/image/cytopia/ansible:latest-k8s.svg?&kill_cache=1)](https://microbadger.com/images/cytopia/ansible:latest-k8s "ansible")
+
+The following Ansible Docker images contain everything from `Ansible tools` and additionally: `docker` and `kubernetes` Python libraries.
+
+| Docker tag   | Build from                           |
+|--------------|--------------------------------------|
+| `latest-k8s` | Latest stable Ansible version        |
+| `2.11-k8s`   | Latest stable Ansible 2.11.x version |
+| `2.10-k8s`   | Latest stable Ansible 2.10.x version |
+| `2.9-k8s`    | Latest stable Ansible 2.9.x version  |
+| `2.8-k8s`    | Latest stable Ansible 2.8.x version  |
+| `2.7-k8s`    | Latest stable Ansible 2.7.x version  |
+| `2.6-k8s`    | Latest stable Ansible 2.6.x version  |
+| `2.5-k8s`    | Latest stable Ansible 2.5.x version  |
+| `2.4-k8s`    | Latest stable Ansible 2.4.x version  |
+| `2.3-k8s`    | Latest stable Ansible 2.3.x version  |
+
 
 ## Docker environment variables
 
@@ -1142,6 +1162,17 @@ make build ANSIBLE=latest FLAVOUR=awshelm HELM=2.14
 # Build Ansible 2.6 with Kops 1.8
 # image: cytopia/ansible:2.6-awshelm1.8
 make build ANSIBLE=2.6 FLAVOUR=awshelm HELM=2.14
+```
+
+### Ansible k8s
+```bash
+# Build latest Ansible k8s
+# image: cytopia/ansible:latest-k8s
+make build ANSIBLE=latest FLAVOUR=k8s
+
+# Build Ansible 2.6 k8s
+# image: cytopia/ansible:2.6-k8s
+make build ANSIBLE=2.6 FLAVOUR=k8s
 ```
 
 


### PR DESCRIPTION
Hi, thanks for great works!

This PR would add `k8s`, which contains the k8s-related python packages (`docker`, `kubernetes`), derived from `tools`.

It's a good choice if you need smaller and `docker`-enabled feature compared with `awsk8s`, running as a Pod in the private kubernetes clusters (such as Bare-metal).

Tested locally and is working.
Also, there are some Github Actions for building and testing the feature.
