### PR TITLE
Release 0.48

### DIFF
--- a/Dockerfiles/Dockerfile-awsk8s
+++ b/Dockerfiles/Dockerfile-awsk8s
@@ -36,8 +36,9 @@ RUN set -eux \
 		fail; \
 	fi \
 	\
+	&& KUBECTL_VERSION="$(curl -sS --fail https://storage.googleapis.com/kubernetes-release/release/stable.txt)" \
 	&& curl -sS -L --fail -o /usr/bin/kubectl \
-		https://storage.googleapis.com/kubernetes-release/release/$(curl -sS --fail https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl \
+		https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl \
 	&& chmod +x /usr/bin/kubectl \
 	&& kubectl version --client --short=true 2>&1 | grep -E 'v[.0-9]+'
 
@@ -49,7 +50,8 @@ RUN set -eux \
 		&& exit 0; \
 	fi \
 	\
-	&& curl -sS -L --fail -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
+	&& curl -sS -L --fail -o /tmp/openshift-client-linux.tar.gz \
+		https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
 	&& mkdir /tmp/openshift-client-linux/ \
 	&& tar -xzf /tmp/openshift-client-linux.tar.gz -C /tmp/openshift-client-linux/ \
 	&& mv /tmp/openshift-client-linux/oc /usr/bin/oc-dynamically-linked \

--- a/Dockerfiles/Dockerfile-base
+++ b/Dockerfiles/Dockerfile-base
@@ -134,7 +134,7 @@ COPY --from=builder /usr/bin/ansible* /usr/bin/
 
 # Pre-compile Python for better performance
 RUN set -eux \
-	&& python3 -m compileall /usr/lib/python3.10
+	&& python3 -m compileall -j 0 /usr/lib/python3.10
 
 WORKDIR /data
 CMD ["/bin/sh"]


### PR DESCRIPTION
# Release 0.48

* Fix: Error, gid/uid already exists
* Use -j 0 for python code compilation
* Variablize kubectl version in separate command