### PR TITLE
Add ansible 2.14

### DIFF
--- a/.github/workflows/params.yml
+++ b/.github/workflows/params.yml
@@ -16,6 +16,7 @@ env:
         "NAME": "ansible",
         "VERSION": [
           "latest",
+          "2.14",
           "2.13",
           "2.12",
           "2.11",

--- a/Dockerfiles/Dockerfile-base
+++ b/Dockerfiles/Dockerfile-base
@@ -65,6 +65,9 @@ RUN set -eux \
 	elif [ "${VERSION}" = "2.13" ]; then\
 		pip3 install --no-cache-dir --no-binary pyyaml ansible~=6.0; \
 	\
+	elif [ "${VERSION}" = "2.14" ]; then\
+		pip3 install --no-cache-dir --no-binary pyyaml ansible~=7.0; \
+	\
 	else \
 		fail; \
 	fi \

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The following Ansible Docker images are as small as possible and only contain An
 | Docker Tag               | Git Ref      | Ansible      | Available Architectures                      |
 |--------------------------|--------------|--------------|----------------------------------------------|
 | **`latest`**             | master       | latest       | `amd64`, `arm64`                             |
+| `2.14`                   | master       | **`2.14.x`** | `amd64`, `arm64`                             |
 | `2.13`                   | master       | **`2.13.x`** | `amd64`, `arm64`                             |
 | `2.12`                   | master       | **`2.12.x`** | `amd64`, `arm64`                             |
 | `2.11`                   | master       | **`2.11.x`** | `amd64`, `arm64`                             |
@@ -123,6 +124,7 @@ The following Ansible Docker images contain everything from `Ansible base` and a
 | Docker Tag               | Git Ref      | Ansible      | Available Architectures                      |
 |--------------------------|--------------|--------------|----------------------------------------------|
 | **`latest-tools`**       | master       | latest       | `amd64`, `arm64`                             |
+| `2.14-tools`             | master       | **`2.14.x`** | `amd64`, `arm64`                             |
 | `2.13-tools`             | master       | **`2.13.x`** | `amd64`, `arm64`                             |
 | `2.12-tools`             | master       | **`2.12.x`** | `amd64`, `arm64`                             |
 | `2.11-tools`             | master       | **`2.11.x`** | `amd64`, `arm64`                             |
@@ -138,6 +140,7 @@ The following Ansible Docker images contain everything from `Ansible tools` and 
 | Docker Tag               | Git Ref      | Ansible      | Available Architectures                      |
 |--------------------------|--------------|--------------|----------------------------------------------|
 | **`latest-azure`**       | master       | latest       | `amd64`, `arm64`                             |
+| `2.14-azure`             | master       | **`2.14.x`** | `amd64`, `arm64`                             |
 | `2.13-azure`             | master       | **`2.13.x`** | `amd64`, `arm64`                             |
 | `2.12-azure`             | master       | **`2.12.x`** | `amd64`, `arm64`                             |
 | `2.11-azure`             | master       | **`2.11.x`** | `amd64`, `arm64`                             |
@@ -153,6 +156,7 @@ The following Ansible Docker images contain everything from `Ansible tools` and 
 | Docker Tag               | Git Ref      | Ansible      | Available Architectures                      |
 |--------------------------|--------------|--------------|----------------------------------------------|
 | **`latest-aws`**         | master       | latest       | `amd64`, `arm64`                             |
+| `2.14-aws`               | master       | **`2.14.x`** | `amd64`, `arm64`                             |
 | `2.13-aws`               | master       | **`2.13.x`** | `amd64`, `arm64`                             |
 | `2.12-aws`               | master       | **`2.12.x`** | `amd64`, `arm64`                             |
 | `2.11-aws`               | master       | **`2.11.x`** | `amd64`, `arm64`                             |
@@ -168,6 +172,7 @@ The following Ansible Docker images contain everything from `Ansible aws` and ad
 | Docker Tag               | Git Ref      | Ansible      | Available Architectures                      |
 |--------------------------|--------------|--------------|----------------------------------------------|
 | **`latest-awsk8s`**      | master       | latest       | `amd64`, `arm64`                             |
+| `2.14-awsk8s`            | master       | **`2.14.x`** | `amd64`, `arm64`                             |
 | `2.13-awsk8s`            | master       | **`2.13.x`** | `amd64`, `arm64`                             |
 | `2.12-awsk8s`            | master       | **`2.12.x`** | `amd64`, `arm64`                             |
 | `2.11-awsk8s`            | master       | **`2.11.x`** | `amd64`, `arm64`                             |
@@ -185,6 +190,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | Docker Tag               | Git Ref      | Ansible      | Kops     | Available Architectures           |
 |--------------------------|--------------|--------------|----------|-----------------------------------|
 | **`latest-awskops1.25`** | master       | latest       | `1.25.x` | `amd64`, `arm64`                  |
+| `2.14-awskops1.25`       | master       | **`2.14.x`** | `1.25.x` | `amd64`, `arm64`                  |
 | `2.13-awskops1.25`       | master       | **`2.13.x`** | `1.25.x` | `amd64`, `arm64`                  |
 | `2.12-awskops1.25`       | master       | **`2.12.x`** | `1.25.x` | `amd64`, `arm64`                  |
 | `2.11-awskops1.25`       | master       | **`2.11.x`** | `1.25.x` | `amd64`, `arm64`                  |
@@ -193,6 +199,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awskops1.25`        | master       | **`2.8.x`**  | `1.25.x` | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awskops1.24`** | master       | latest       | `1.24.x` | `amd64`, `arm64`                  |
+| `2.14-awskops1.24`       | master       | **`2.14.x`** | `1.24.x` | `amd64`, `arm64`                  |
 | `2.13-awskops1.24`       | master       | **`2.13.x`** | `1.24.x` | `amd64`, `arm64`                  |
 | `2.12-awskops1.24`       | master       | **`2.12.x`** | `1.24.x` | `amd64`, `arm64`                  |
 | `2.11-awskops1.24`       | master       | **`2.11.x`** | `1.24.x` | `amd64`, `arm64`                  |
@@ -201,6 +208,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awskops1.24`        | master       | **`2.8.x`**  | `1.24.x` | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awskops1.23`** | master       | latest       | `1.23.x` | `amd64`, `arm64`                  |
+| `2.14-awskops1.23`       | master       | **`2.14.x`** | `1.23.x` | `amd64`, `arm64`                  |
 | `2.13-awskops1.23`       | master       | **`2.13.x`** | `1.23.x` | `amd64`, `arm64`                  |
 | `2.12-awskops1.23`       | master       | **`2.12.x`** | `1.23.x` | `amd64`, `arm64`                  |
 | `2.11-awskops1.23`       | master       | **`2.11.x`** | `1.23.x` | `amd64`, `arm64`                  |
@@ -209,6 +217,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awskops1.23`        | master       | **`2.8.x`**  | `1.23.x` | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awskops1.22`** | master       | latest       | `1.22.x` | `amd64`, `arm64`                  |
+| `2.14-awskops1.22`       | master       | **`2.14.x`** | `1.22.x` | `amd64`, `arm64`                  |
 | `2.13-awskops1.22`       | master       | **`2.13.x`** | `1.22.x` | `amd64`, `arm64`                  |
 | `2.12-awskops1.22`       | master       | **`2.12.x`** | `1.22.x` | `amd64`, `arm64`                  |
 | `2.11-awskops1.22`       | master       | **`2.11.x`** | `1.22.x` | `amd64`, `arm64`                  |
@@ -217,6 +226,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awskops1.22`        | master       | **`2.8.x`**  | `1.22.x` | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awskops1.21`** | master       | latest       | `1.21.x` | `amd64`, `arm64`                  |
+| `2.14-awskops1.21`       | master       | **`2.14.x`** | `1.21.x` | `amd64`, `arm64`                  |
 | `2.13-awskops1.21`       | master       | **`2.13.x`** | `1.21.x` | `amd64`, `arm64`                  |
 | `2.12-awskops1.21`       | master       | **`2.12.x`** | `1.21.x` | `amd64`, `arm64`                  |
 | `2.11-awskops1.21`       | master       | **`2.11.x`** | `1.21.x` | `amd64`, `arm64`                  |
@@ -225,6 +235,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awskops1.21`        | master       | **`2.8.x`**  | `1.21.x` | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awskops1.20`** | master       | latest       | `1.20.x` | `amd64`, `arm64`                  |
+| `2.14-awskops1.20`       | master       | **`2.14.x`** | `1.20.x` | `amd64`, `arm64`                  |
 | `2.13-awskops1.20`       | master       | **`2.13.x`** | `1.20.x` | `amd64`, `arm64`                  |
 | `2.12-awskops1.20`       | master       | **`2.12.x`** | `1.20.x` | `amd64`, `arm64`                  |
 | `2.11-awskops1.20`       | master       | **`2.11.x`** | `1.20.x` | `amd64`, `arm64`                  |
@@ -233,6 +244,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awskops1.20`        | master       | **`2.8.x`**  | `1.20.x` | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awskops1.19`** | master       | latest       | `1.19.x` | `amd64`, `arm64`                  |
+| `2.14-awskops1.19`       | master       | **`2.14.x`** | `1.19.x` | `amd64`, `arm64`                  |
 | `2.13-awskops1.19`       | master       | **`2.13.x`** | `1.19.x` | `amd64`, `arm64`                  |
 | `2.12-awskops1.19`       | master       | **`2.12.x`** | `1.19.x` | `amd64`, `arm64`                  |
 | `2.11-awskops1.19`       | master       | **`2.11.x`** | `1.19.x` | `amd64`, `arm64`                  |
@@ -250,6 +262,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | Docker Tag               | Git Ref      | Ansible      | Helm     | Available Architectures           |
 |--------------------------|--------------|--------------|----------|-----------------------------------|
 | **`latest-awshelm3.11`** | master       | latest       | `3.11.x` | `amd64`, `arm64`                  |
+| `2.14-awshelm3.11`       | master       | **`2.14.x`** | `3.11.x` | `amd64`, `arm64`                  |
 | `2.13-awshelm3.11`       | master       | **`2.13.x`** | `3.11.x` | `amd64`, `arm64`                  |
 | `2.12-awshelm3.11`       | master       | **`2.12.x`** | `3.11.x` | `amd64`, `arm64`                  |
 | `2.11-awshelm3.11`       | master       | **`2.11.x`** | `3.11.x` | `amd64`, `arm64`                  |
@@ -258,6 +271,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.11`        | master       | **`2.8.x`**  | `3.11.x` | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.10`** | master       | latest       | `3.10.x` | `amd64`, `arm64`                  |
+| `2.14-awshelm3.10`       | master       | **`2.14.x`** | `3.10.x` | `amd64`, `arm64`                  |
 | `2.13-awshelm3.10`       | master       | **`2.13.x`** | `3.10.x` | `amd64`, `arm64`                  |
 | `2.12-awshelm3.10`       | master       | **`2.12.x`** | `3.10.x` | `amd64`, `arm64`                  |
 | `2.11-awshelm3.10`       | master       | **`2.11.x`** | `3.10.x` | `amd64`, `arm64`                  |
@@ -266,6 +280,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.10`        | master       | **`2.8.x`**  | `3.10.x` | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.9`**  | master       | latest       | `3.9.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.9`        | master       | **`2.14.x`** | `3.9.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.9`        | master       | **`2.13.x`** | `3.9.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.9`        | master       | **`2.12.x`** | `3.9.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.9`        | master       | **`2.11.x`** | `3.9.x`  | `amd64`, `arm64`                  |
@@ -274,6 +289,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.9`         | master       | **`2.8.x`**  | `3.9.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.8`**  | master       | latest       | `3.8.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.8`        | master       | **`2.14.x`** | `3.8.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.8`        | master       | **`2.13.x`** | `3.8.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.8`        | master       | **`2.12.x`** | `3.8.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.8`        | master       | **`2.11.x`** | `3.8.x`  | `amd64`, `arm64`                  |
@@ -282,6 +298,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.8`         | master       | **`2.8.x`**  | `3.8.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.7`**  | master       | latest       | `3.7.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.7`        | master       | **`2.14.x`** | `3.7.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.7`        | master       | **`2.13.x`** | `3.7.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.7`        | master       | **`2.12.x`** | `3.7.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.7`        | master       | **`2.11.x`** | `3.7.x`  | `amd64`, `arm64`                  |
@@ -290,6 +307,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.7`         | master       | **`2.8.x`**  | `3.7.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.6`**  | master       | latest       | `3.6.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.6`        | master       | **`2.14.x`** | `3.6.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.6`        | master       | **`2.13.x`** | `3.6.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.6`        | master       | **`2.12.x`** | `3.6.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.6`        | master       | **`2.11.x`** | `3.6.x`  | `amd64`, `arm64`                  |
@@ -298,6 +316,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.6`         | master       | **`2.8.x`**  | `3.6.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.5`**  | master       | latest       | `3.5.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.5`        | master       | **`2.14.x`** | `3.5.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.5`        | master       | **`2.13.x`** | `3.5.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.5`        | master       | **`2.12.x`** | `3.5.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.5`        | master       | **`2.11.x`** | `3.5.x`  | `amd64`, `arm64`                  |
@@ -306,6 +325,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.5`         | master       | **`2.8.x`**  | `3.5.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.4`**  | master       | latest       | `3.4.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.4`        | master       | **`2.14.x`** | `3.4.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.4`        | master       | **`2.13.x`** | `3.4.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.4`        | master       | **`2.12.x`** | `3.4.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.4`        | master       | **`2.11.x`** | `3.4.x`  | `amd64`, `arm64`                  |
@@ -314,6 +334,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.4`         | master       | **`2.8.x`**  | `3.4.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.3`**  | master       | latest       | `3.3.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.3`        | master       | **`2.14.x`** | `3.3.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.3`        | master       | **`2.13.x`** | `3.3.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.3`        | master       | **`2.12.x`** | `3.3.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.3`        | master       | **`2.11.x`** | `3.3.x`  | `amd64`, `arm64`                  |
@@ -322,6 +343,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.3`         | master       | **`2.8.x`**  | `3.3.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.2`**  | master       | latest       | `3.2.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.2`        | master       | **`2.14.x`** | `3.2.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.2`        | master       | **`2.13.x`** | `3.2.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.2`        | master       | **`2.12.x`** | `3.2.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.2`        | master       | **`2.11.x`** | `3.2.x`  | `amd64`, `arm64`                  |
@@ -330,6 +352,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.2`         | master       | **`2.8.x`**  | `3.2.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.1`**  | master       | latest       | `3.1.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.1`        | master       | **`2.14.x`** | `3.1.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.1`        | master       | **`2.13.x`** | `3.1.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.1`        | master       | **`2.12.x`** | `3.1.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.1`        | master       | **`2.11.x`** | `3.1.x`  | `amd64`, `arm64`                  |
@@ -338,6 +361,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.1`         | master       | **`2.8.x`**  | `3.1.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm3.0`**  | master       | latest       | `3.0.x`  | `amd64`, `arm64`                  |
+| `2.14-awshelm3.0`        | master       | **`2.14.x`** | `3.0.x`  | `amd64`, `arm64`                  |
 | `2.13-awshelm3.0`        | master       | **`2.13.x`** | `3.0.x`  | `amd64`, `arm64`                  |
 | `2.12-awshelm3.0`        | master       | **`2.12.x`** | `3.0.x`  | `amd64`, `arm64`                  |
 | `2.11-awshelm3.0`        | master       | **`2.11.x`** | `3.0.x`  | `amd64`, `arm64`                  |
@@ -346,6 +370,7 @@ The following Ansible Docker images contain everything from `Ansible awsk8s` and
 | `2.8-awshelm3.0`         | master       | **`2.8.x`**  | `3.0.x`  | `amd64`, `arm64`                  |
 |                          |              |              |          |                                   |
 | **`latest-awshelm2.16`** | master       | latest       | `2.16.x` | `amd64`, `arm64`                  |
+| `2.14-awshelm2.16`       | master       | **`2.14.x`** | `2.16.x` | `amd64`, `arm64`                  |
 | `2.13-awshelm2.16`       | master       | **`2.13.x`** | `2.16.x` | `amd64`, `arm64`                  |
 | `2.12-awshelm2.16`       | master       | **`2.12.x`** | `2.16.x` | `amd64`, `arm64`                  |
 | `2.11-awshelm2.16`       | master       | **`2.11.x`** | `2.16.x` | `amd64`, `arm64`                  |


### PR DESCRIPTION
According to https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs Ansible 2.14 is the current version. This PR adds that one.

Closes https://github.com/cytopia/docker-ansible/issues/126