### PR TITLE
Add python lib 'jc' to flavour infra

### DIFF
--- a/Dockerfiles/Dockerfile-infra
+++ b/Dockerfiles/Dockerfile-infra
@@ -28,6 +28,7 @@ RUN set -eux \
 		PyMySQL \
 		docker \
 		docker-compose \
+		jc \
 		jsondiff \
 		netaddr \
 		pexpect \

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following table shows a quick overview of provided libraries and tools for e
 |---------|---------------|------------------------|---------------------|
 | base    | -        | `cffi`, `cryptography`, `Jinja2`, `junit-xml`, `lxml`, `paramiko`, `PyYAML` | - |
 | tools   | base     | `dnspython`, `JMESPath`, `mitogen` | `bash`, `git`, `gpg`, `jq`, `ssh`, `yq` |
-| infra   | tools    | `docker`, `docker-compose`, `jsondiff`, `netaddr`, `pexpect`, `psycopg2`, `pyldap`, `pypsexec`, `pymongo`, `PyMySQL`, `pywinrm`, `smbprotocol` | `rsync`, `sshpass` |
+| infra   | tools    | `docker`, `docker-compose`, `jc`, `jsondiff`, `netaddr`, `pexpect`, `psycopg2`, `pyldap`, `pypsexec`, `pymongo`, `PyMySQL`, `pywinrm`, `smbprotocol` | `rsync`, `sshpass` |
 | azure   | tools    | `azure-*`              | `az` |
 | aws     | tools    | `awscli`, `botocore`, `boto`, `boto3` | `aws`, `aws-iam-authenticator` |
 | awsk8s  | aws      | `openshift`            | `kubectl`, `oc` |


### PR DESCRIPTION

The python lib [jc](https://github.com/kellyjonbrazil/jc) is a [requirement for the community.general.jc filter](https://docs.ansible.com/ansible/latest/collections/community/general/jc_filter.html#requirements).

Closes: #129